### PR TITLE
Adds capiche to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ I'm not opposed to including remote friendly companies that have a Go developers
 | ------------ | ----------- | ------------------- | ------------ |
 | [Segment](https://segment.com/) | data infrastrucutre | ? | backend and saas apis? |
 | [Klei Entertainment](https://klei.com/) | Video Games | ? | backend/devops |
-| [BPI](https://www.bpi-software.com/) | b2b | ? | backend? |
+| [BPI](https://www.bpi-software.com/) | b2b | ? | backend? |  
+| [Capiche](https://capiche.io) | b2b | 2 devs / 1 local / ? | backend/cloud |  


### PR DESCRIPTION
For clarity, our current production stack is mostly PHP and Node based; however, we have just kicked off some work in Go, and anticipate it being our main language for most of our new work.